### PR TITLE
Fix test spec for no-medications-error component

### DIFF
--- a/src/app/no-medications-error/no-medications-error.component.spec.ts
+++ b/src/app/no-medications-error/no-medications-error.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
-import { AddMedicationsModalComponent } from './no-medications-error.component';
+import { NoMedicationsErrorComponent } from './no-medications-error.component';
 
-describe('AddMedicationsModalComponent', () => {
-  let component: AddMedicationsModalComponent;
-  let fixture: ComponentFixture<AddMedicationsModalComponent>;
+describe('NoMedicationsErrorComponent', () => {
+  let component: NoMedicationsErrorComponent;
+  let fixture: ComponentFixture<NoMedicationsErrorComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ AddMedicationsModalComponent ],
+      declarations: [ NoMedicationsErrorComponent ],
       imports: [IonicModule.forRoot()]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(AddMedicationsModalComponent);
+    fixture = TestBed.createComponent(NoMedicationsErrorComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   }));


### PR DESCRIPTION
## Summary
- fix wrong component import/name in spec

## Testing
- `npm run lint`
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f49ee97c4832c8e2ed2b7f44e6128