### PR TITLE
Implement medication countdown timer

### DIFF
--- a/src/app/medications/medications.page.html
+++ b/src/app/medications/medications.page.html
@@ -22,8 +22,9 @@
     </ion-card-header>
     <ion-card-content>
       {{ medication.nextDoseTime.dateString }} at
-      {{medication.nextDoseTime.timeString}}</ion-card-content
-    >
+      {{ medication.nextDoseTime.timeString }}
+      <div>Time remaining: {{ medication.timeRemaining }}</div>
+    </ion-card-content>
     <ion-button fill="clear" [strong]="true" class="custom-padding-button"
       >Skip</ion-button
     >


### PR DESCRIPTION
## Summary
- compute time remaining until next dose
- update medication card template to show a timer

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Chrome missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f4fc15ea4832caf1fa48f45b991ff